### PR TITLE
DDCYLS-8267

### DIFF
--- a/app/uk/gov/hmrc/digitalservicestax/views/cya/CheckYourAnswersReg.scala.html
+++ b/app/uk/gov/hmrc/digitalservicestax/views/cya/CheckYourAnswersReg.scala.html
@@ -45,7 +45,7 @@
             actions = Some(Actions(
                 items = Seq(
                     ActionItem(
-                        href = s"$serviceUrl/${if(in.companyReg.useSafeId){"company-name"} else {"confirm-company-details"}}",
+                        href = s"$serviceUrl/${if(in.companyReg.useSafeId){"check-company-registered-office-address"} else {"confirm-company-details"}}",
                         content = HtmlContent(messages("common.change")),
                         visuallyHiddenText = Some(messages(s"$key.company-name-and-reg-address.change").toString)
                     )


### PR DESCRIPTION
A bug has arisen where a user who enters an international address for the registered company address can amend their address from th CYA page & select the "United Kingdom" option without having to enter a postcode since one is not asked for on the international address entry page thus bypassing postcode entry.

The backend model also reads the United Kingdom selection & will use 'GB' as the country code but still wrap the address as a ForeignAddress Model which is incorrect.

This change redirects the user back a page further where they are asked whether the company's registered address is in the UK or not thus forcing postcode entry. It also corrects the model in the backend using UkAddress.